### PR TITLE
Add terraform scripts for provisioning Packet Github Actions Runners

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 bosh/vars/*
 .idea/
+.terraform/
+*.tfstate
+*.tfstate.backup

--- a/runners/README.md
+++ b/runners/README.md
@@ -1,0 +1,69 @@
+# Usage
+
+For managing a Windows Github Actions Runner, one only needs to interact with the _terraform wrapper_ script at: `./scripts/terraformw.sh`. The script wraps terraform commands; performing any prep steps before the main operations.
+
+## Configure LastPass First
+
+The script assumes that the following 2 credential notes are available in LastPass:
+
+1.  **PACKET_AUTH_TOKEN:** An authentication token that allows terraform to manage instances on your behalf.
+    ```
+    lpass show --note 'Shared-Cloud Native Buildpacks/packet-auth-token'
+    ```
+1.  **PACKET_PROJECT_ID:** The GUID representing a packet project where instances will be created.
+    ```
+    lpass show --note 'Shared-Cloud Native Buildpacks/packet-project-id'
+    ```
+
+## Create a runner
+
+To create a runner, invoke the _terraform wrapper_ script without any arguments:
+```bash
+# pwd: ~/workspace/ci/runners
+$ ./scripts/terraformw.sh
+...
+```
+
+> **Note:** This command will take about 20 minutes.
+
+The process will standup a windows machine and perform _the bulk_ of the provisioning steps. These steps include: Installing Hyper-V/Docker-Desktop, Preparing the `actions-runner-win-x64-*.zip` archive, Rebooting the Machine, and more.
+
+However after the creation process is completed, one must still manually **log into the machine and turn on the Docker-Desktop Application**. (It has proven difficult to do well programmatically).
+
+## Destroying a runner
+
+To destroy a runner, invoke the _terraform wrapper_ script with the `destroy` argument:
+```bash
+# pwd: ~/workspace/ci/runners
+$ ./scripts/terraformw.sh destroy
+...
+```
+
+> **Note:** This command will take about 6 seconds.
+
+## Viewing runner credentials
+
+To view credentials for a runner, invoke the _terraform wrapper_ script with the `output` argument:
+```bash
+# pwd: ~/workspace/ci/runners
+$ ./scripts/terraformw.sh output
+...
+hostname = windows-lcow
+public_ip = xxx.xx.xx.100
+root_password = <sensitive>
+root_username = Admin
+```
+
+The password for the machine is marked 'sensitive'. To view the password, you must explicitly request to view its contents:
+```bash
+# pwd: ~/workspace/ci/runners
+$ ./scripts/terraformw.sh output root_password
+...
+0123abcdefghijklmn
+```
+
+## Other
+
+* To specify the type of machine to be created, one must [edit the `packet_device.gha_lcow` resource definition of `main.tf`](./terraform/main.tf). The documentation can be found [here](https://registry.terraform.io/providers/packethost/packet/latest/docs/resources/device#project_ssh_key_ids).
+* To adjust what happens during the provisioning process, one must [edit the `provision.ps1`](./terraform/provision.ps1) file.
+* Any valid terraform arguments can be passed to `terraformw.sh`.

--- a/runners/scripts/terraformw.sh
+++ b/runners/scripts/terraformw.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+RED='\033[1;31m'
+NC='\033[0m' # No Color
+
+terraform --help &> /dev/null
+if [[ $? != 0 ]]; then
+  echo -e "${RED}Error${NC}: Terraform must be installed and on the PATH: brew install terraform"
+  exit 1
+fi
+
+set -e
+
+DIR=$(cd $(dirname "$0") && cd .. && pwd)
+
+# TODO: these credentials are to be set up by maintainers
+export TF_VAR_PACKET_AUTH_TOKEN="$(lpass show --note 'Shared-Cloud Native Buildpacks/packet-auth-token')"
+export TF_VAR_PROJECT_ID="$(lpass show --note 'Shared-Cloud Native Buildpacks/packet-project-id')"
+
+cd "$DIR/terraform"
+if [ -z "$1" ] || [ "$1" == "apply" ]; then
+  terraform init
+  terraform plan
+fi
+terraform ${@:-apply}

--- a/runners/terraform/main.tf
+++ b/runners/terraform/main.tf
@@ -1,0 +1,68 @@
+variable "PACKET_AUTH_TOKEN" {
+  type        = string
+  description = "Auth Token for connection to packet.net"
+}
+variable "PACKET_PROJECT_ID" {
+  type        = string
+  description = "Packet Project GUID"
+}
+
+provider "packet" {
+  auth_token = var.PACKET_AUTH_TOKEN
+}
+
+locals {
+  project_id = var.PACKET_PROJECT_ID
+}
+
+resource "packet_device" "gha_lcow" {
+  hostname            = "windows-lcow"
+  plan                = "c3.small.x86"
+  facilities          = ["dfw2"]
+  operating_system    = "windows_2019"
+  billing_cycle       = "hourly"
+  project_id          = local.project_id
+  user_data           = file("user_data.ps1")
+}
+
+resource "null_resource" "provision" {
+  connection {
+    type = "ssh"
+    host = packet_device.gha_lcow.access_public_ipv4
+    user = "Admin"
+    password = packet_device.gha_lcow.root_password
+    script_path = "/Windows/Temp/terraform_%RAND%.bat"
+  }
+
+  provisioner "local-exec" {
+    command = "./wait-for-ssh.sh ${packet_device.gha_lcow.access_public_ipv4}"
+  }
+
+  provisioner "file" {
+    source = "provision.ps1"
+    destination = "C:/provision.ps1"
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "powershell.exe C:/provision.ps1 > C:/provision.log"
+    ]
+  }
+}
+
+output "hostname" {
+  value = packet_device.gha_lcow.hostname
+}
+
+output "root_username" {
+  value = "Admin"
+}
+
+output "root_password" {
+  value = packet_device.gha_lcow.root_password
+  sensitive = true
+}
+
+output "public_ip" {
+  value = packet_device.gha_lcow.access_public_ipv4
+}

--- a/runners/terraform/provision.ps1
+++ b/runners/terraform/provision.ps1
@@ -1,0 +1,20 @@
+# Install chocolatey (https://chocolatey.org/install)
+Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
+choco install docker-desktop git make cygwin -y
+
+# Set up Github Actions Runner Process
+## IMPORTANT:
+## Each runner is specific to only one git repository. To reuse the same VM, you must run a service per repo.
+## Convention is to install each runner in a directory named after the repo. eg. `\actions-runners\pack\`
+Set-Variable -Name REPO -Value pack
+mkdir \actions-runners\$REPO
+Push-Location \actions-runners\$REPO
+  curl.exe -Lo actions-runner-win-x64-2.168.0.zip https://github.com/actions/runner/releases/download/v2.168.0/actions-runner-win-x64-2.168.0.zip
+  Expand-Archive actions-runner-win-x64-2.168.0.zip
+Pop-Location
+
+# Disable automatic CRLF
+& "C:\Program Files\Git\cmd\git.exe" config --global core.autocrlf false
+
+# Add cygwin binaries path
+[Environment]::SetEnvironmentVariable("PATH", "$ENV:PATH;C:\tools\cygwin\bin", "USER")

--- a/runners/terraform/user_data.ps1
+++ b/runners/terraform/user_data.ps1
@@ -1,0 +1,9 @@
+#ps1
+
+# Install/Enable SSH (for subsequent provisioning steps)
+Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0
+Set-Service -Name sshd -StartupType Automatic
+Start-Service sshd
+
+# Install Hyper-V for Docker; NOTE: This will restart the machine.
+Install-WindowsFeature -Name Hyper-V -IncludeManagementTools -Restart

--- a/runners/terraform/versions.tf
+++ b/runners/terraform/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    packet = {
+      source = "terraform-providers/packet"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/runners/terraform/wait-for-ssh.sh
+++ b/runners/terraform/wait-for-ssh.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+attempts=0
+host=$1
+
+if [ -z "$host" ]; then
+  echo "SSH host must be provided as an argument"
+  exit 1
+fi
+
+echo "Waiting for SSH..."
+while [ $attempts -lt 15 ]; do
+  if nc -z "$host" 22; then
+    echo "SSH Connected!"
+    exit 0
+  fi
+
+  ((attempts+=1))
+  sleep 1
+done
+
+echo "SSH Connection Failed."
+exit 1


### PR DESCRIPTION
<img width="782" alt="terraform-apply" src="https://user-images.githubusercontent.com/4236888/93031725-1835d900-f5fb-11ea-9fad-758ab9c6e089.png">

Introduces scripts that automate the creation and provisioning of packet.net **Windows** Github Actions Runners using terraform. Provisioning steps are extracted from [the wiki documentation](https://github.com/buildpacks/ci/wiki/Windows-GitHub-Actions-Runner#for-lcow-only).

[#174630303]

## To be discussed

- Terraform drops sensitive information in the form of `.tfstate` files in the working directory. These are git-ignored as part of this PR, but one would need to decide a way to keep these in sync across workstations. For instance, terraform provides an authenticated [GCS Backend](https://www.terraform.io/docs/backends/types/gcs.html) as an alternative destination for `.tfstate` files.

----

# Usage

For managing a Windows Github Actions Runner, one only needs to interact with the _terraform wrapper_ script at: `./runners/scripts/terraformw.sh`. The script wraps terraform commands; performing any prep steps before the main operations.

## Configure LastPass First

The script assumes that the following 2 credential notes are available in LastPass:

1.  **PACKET_AUTH_TOKEN:** An authentication token that allows terraform to manage instances on your behalf.
    `lpass show --note 'Shared-Cloud Native Buildpacks/packet-auth-token'`
1.  **PACKET_PROJECT_ID:** The GUID representing a packet project where instances will be created.
    `lpass show --note 'Shared-Cloud Native Buildpacks/packet-project-id'`

## Create a runner

To create a runner, invoke the _terraform wrapper_ script without any arguments:
```bash
# pwd: ~/workspace/ci
$ ./runners/scripts/terraformw.sh
...
```

> **Note:** This command will take about 20 minutes.

The process will standup a windows machine and perform _much_ of the provisioning steps covered [the wiki documentation](https://github.com/buildpacks/ci/wiki/Windows-GitHub-Actions-Runner#for-lcow-only). These steps include: Installing Hyper-V/Docker-Desktop, Preparing the `actions-runner-win-x64-*.zip` archive, Rebooting the Machine, and more.

However after the creation process is completed, one must still manually **log into the machine and turn on the Docker-Desktop Application**. (I've been unable to find out how to do this well programmatically).

## Destroying a runner

To destroy a runner, invoke the _terraform wrapper_ script with the `destroy` argument:
```bash
# pwd: ~/workspace/ci
$ ./runners/scripts/terraformw.sh destroy
...
```

> **Note:** This command will take about 6 seconds.

## Viewing runner credentials

To view credentials for a runner, invoke the _terraform wrapper_ script with the `output` argument:
```bash
# pwd: ~/workspace/ci
$ ./runners/scripts/terraformw.sh output
...
hostname = windows-lcow
public_ip = xxx.xx.xx.100
root_password = <sensitive>
root_username = Admin
```

The password for the machine is marked 'sensitive'. To view the password, you must explicitly request to view its contents:
```bash
# pwd: ~/workspace/ci
$ ./runners/scripts/terraformw.sh output root_password
...
0123abcdefghijklmn
```

## Other

* To specify the type of machine to be created, one must [edit the resource spec of `main.tf`](https://github.com/buildpacks/ci/pull/21/files#diff-e0e34ee91f16e70893e45c9b2a13b2e1R18-R26). The documentation can be found [here](https://registry.terraform.io/providers/packethost/packet/latest/docs/resources/device#project_ssh_key_ids).
* To adjust what happens during the provisioning process, one must [edit the `provision.ps1`](https://github.com/buildpacks/ci/pull/21/files#diff-3abb198fbd296bee844f2444b1fff05c) file.
* Any valid terraform arguments can be passed to `terraformw.sh`. 
