### PR TITLE
Fix docker desktop install

### DIFF
--- a/gh-runners/windows/main.tf
+++ b/gh-runners/windows/main.tf
@@ -6,7 +6,7 @@ resource "metal_device" "windows-lcow" {
   project_id       = var.METAL_PROJECT_ID
   hostname         = "windows-lcow-gh-runner"
   operating_system = "windows_2019"
-  facilities       = ["dfw2", "iad2"]
+  facilities       = ["da11", "dfw2", "iad1", "dc13"]
   plan             = "c3.small.x86"
   billing_cycle    = "hourly"
   user_data        = file("provision-scripts/user_data.ps1")
@@ -27,7 +27,7 @@ resource "metal_device" "windows-wcow" {
   project_id       = var.METAL_PROJECT_ID
   hostname         = "windows-wcow-gh-runner"
   operating_system = "windows_2019"
-  facilities       = ["dfw2", "iad2"]
+  facilities       = ["da11", "dfw2", "iad1", "dc13"]
   plan             = "c3.small.x86"
   billing_cycle    = "hourly"
   user_data        = file("provision-scripts/user_data.ps1")
@@ -48,7 +48,7 @@ resource "metal_device" "windows-workstation1" {
   project_id       = var.METAL_PROJECT_ID
   hostname         = "windows-workstation1"
   operating_system = "windows_2019"
-  facilities       = ["dfw2", "iad2"]
+  facilities       = ["da11", "dfw2", "iad1", "dc13"]
   plan             = "c3.small.x86"
   billing_cycle    = "hourly"
   user_data        = file("provision-scripts/user_data.ps1")

--- a/gh-runners/windows/provision-scripts/docker.create.ps1
+++ b/gh-runners/windows/provision-scripts/docker.create.ps1
@@ -1,7 +1,11 @@
 $ErrorActionPreference = "Stop"
 
 echo "> Installing Docker..."
-choco install docker-desktop --version=3.1.0 -y
+# http://disq.us/p/2j8w5a4: Docker-Desktop v 3.1.0 has a broken checksum
+choco install docker-desktop --version=3.1.0 -y --ignore-checksums
 
 echo "> Restarting..."
 shutdown.exe /r /t 5
+
+# https://github.com/docker/for-win/issues/11899#issuecomment-905413951
+attrib c:\programdata\docker\panic.log -r


### PR DESCRIPTION
Signed-off-by: David Freilich <david.freilich@appsflyer.com>

Docker desktop v3.1.0 has a broken checksum on choco, and the only version with fixed checksums are post 4.0.0, and have a newer service agreement. 